### PR TITLE
Update .gitmodules to clone pybind using https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "extern/pybind11"]
 	path = extern/pybind11
-	url = git@github.com:pybind/pybind11.git
+	url = https://github.com/pybind/pybind11.git
 	branch = stable


### PR DESCRIPTION
This makes it possible to install mimir without having to create an ssh key. Running tests with GH Actions becomes easier that way