### PR TITLE
Add boost graph concepts

### DIFF
--- a/include/mimir/datasets/boost_adapter.hpp
+++ b/include/mimir/datasets/boost_adapter.hpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024 Till Hofmann
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIMIR_DATASETS_BOOST_ADAPTER_HPP_
+#define MIMIR_DATASETS_BOOST_ADAPTER_HPP_
+
+#include "mimir/datasets/state_space.hpp"
+#include "mimir/datasets/transition_system.hpp"
+
+#include <boost/graph/graph_concepts.hpp>
+#include <boost/graph/graph_traits.hpp>
+#include <ranges>
+
+namespace mimir
+{
+struct StateIndexRangeView : std::ranges::iota_view<StateIndex, StateIndex>
+{
+    using std::ranges::iota_view<StateIndex, StateIndex>::iota_view;
+};
+}
+
+template<>
+inline constexpr bool std::ranges::enable_borrowed_range<mimir::StateIndexRangeView> = true;
+
+namespace boost
+{
+template<mimir::IsTransitionSystem TransitionSystem>
+struct graph_traits<TransitionSystem>
+{
+    using vertex_descriptor = mimir::StateIndex;
+    using edge_descriptor = mimir::TransitionIndex;
+    using directed_category = directed_tag;
+    using edge_parallel_category = allow_parallel_edge_tag;
+    using traversal_category = vertex_list_graph_tag;
+    using vertices_size_type = size_t;
+    using edges_size_type = size_t;
+    using vertex_iterator = std::ranges::iterator_t<mimir::StateIndexRangeView>;
+};
+
+}
+
+namespace mimir
+{
+
+template<IsTransitionSystem TransitionSystem>
+std::pair<typename boost::graph_traits<TransitionSystem>::vertex_iterator, typename boost::graph_traits<TransitionSystem>::vertex_iterator>
+vertices(const TransitionSystem& g)
+{
+    StateIndexRangeView range(0, g.get_num_states());
+    // Make sure we can return dangling iterators.
+    static_assert(std::ranges::borrowed_range<StateIndexRangeView>);
+    return std::make_pair(range.begin(), range.end());
+}
+
+template<IsTransitionSystem TransitionSystem>
+boost::graph_traits<TransitionSystem>::vertices_size_type num_vertices(const TransitionSystem& g)
+{
+    return g.get_num_states();
+}
+
+BOOST_CONCEPT_ASSERT((boost::GraphConcept<StateSpace>) );
+BOOST_CONCEPT_ASSERT((boost::VertexListGraphConcept<StateSpace>) );
+}
+
+#endif

--- a/tests/unit/datasets/state_space.cpp
+++ b/tests/unit/datasets/state_space.cpp
@@ -47,4 +47,33 @@ TEST(MimirTests, DatasetsStateSpaceVertexListGraphTest)
     }
     EXPECT_EQ(it, last);
 }
+
+TEST(MimirTests, DatasetsStateSpaceIncidenceGraphTest)
+{
+    const auto domain_file = fs::path(std::string(DATA_DIR) + "gripper/domain.pddl");
+    const auto problem_file = fs::path(std::string(DATA_DIR) + "gripper/p-2-0.pddl");
+    const auto state_space = StateSpace::create(domain_file, problem_file).value();
+
+    size_t transition_count = 0;
+    for (auto [state_it, state_last] = vertices(state_space); state_it != state_last; ++state_it)
+    {
+        const auto& state_id = *state_it;
+        size_t state_transition_count = 0;
+        for (auto [out_it, out_last] = out_edges(state_id, state_space); out_it != out_last; ++out_it)
+        {
+            EXPECT_EQ(source(*out_it, state_space), state_id);
+            transition_count++;
+            state_transition_count++;
+        }
+        // Counting the number of transitions should give us the out degree.
+        EXPECT_EQ(out_degree(*state_it, state_space), state_transition_count);
+    }
+    // Summing over the successors of each state should give the total number of transitions.
+    EXPECT_EQ(transition_count, state_space.get_num_transitions());
+
+    // possible actions:
+    // pick(ball1, rooma, right), pick(ball1, rooma, left), pick(ball2, rooma, right), pick(ball2, rooma, left)
+    // move(rooma, rooma), move(rooma, roomb)
+    EXPECT_EQ(out_degree(state_space.get_initial_state(), state_space), 6);
+}
 }

--- a/tests/unit/datasets/state_space.cpp
+++ b/tests/unit/datasets/state_space.cpp
@@ -1,5 +1,7 @@
 #include "mimir/datasets/state_space.hpp"
 
+#include "mimir/datasets/boost_adapter.hpp"
+
 #include <gtest/gtest.h>
 
 namespace mimir::tests
@@ -28,5 +30,21 @@ TEST(MimirTests, DatasetsStateSpaceCreateParallelTest)
     const auto state_spaces = StateSpace::create(domain_file, problem_files);
 
     EXPECT_EQ(state_spaces.size(), 2);
+}
+
+TEST(MimirTests, DatasetsStateSpaceVertexListGraphTest)
+{
+    const auto domain_file = fs::path(std::string(DATA_DIR) + "gripper/domain.pddl");
+    const auto problem_file = fs::path(std::string(DATA_DIR) + "gripper/p-2-0.pddl");
+    const auto state_space = StateSpace::create(domain_file, problem_file).value();
+
+    EXPECT_EQ(num_vertices(state_space), 28);
+
+    auto [it, last] = vertices(state_space);
+    for (int i = 0; i < 28; ++i, ++it)
+    {
+        EXPECT_EQ(*it, i);
+    }
+    EXPECT_EQ(it, last);
 }
 }


### PR DESCRIPTION
Implement Boost's [`VertexListGraphConcept`](https://www.boost.org/doc/libs/1_85_0/libs/graph/doc/VertexListGraph.html) and [`IncidenceGraphConcept`](https://www.boost.org/doc/libs/1_85_0/libs/graph/doc/IncidenceGraph.html) so we can later use Boost's [`strong_components`](https://www.boost.org/doc/libs/1_85_0/libs/graph/doc/strong_components.html) to compute the strongly connected components in the state graph.