### PR TITLE
Extend boost adapter to support strong_components

### DIFF
--- a/include/mimir/datasets/boost_adapter.hpp
+++ b/include/mimir/datasets/boost_adapter.hpp
@@ -124,17 +124,21 @@ struct IdIsIndexVertexIndex
 };
 }
 
+namespace boost
+{
 template<>
-struct boost::property_traits<mimir::IdIsIndexVertexIndex>
+struct property_traits<mimir::IdIsIndexVertexIndex>
 {
     using value_type = mimir::StateIndex;
     using key_type = mimir::StateIndex;
     using reference = mimir::StateIndex;
     using category = boost::readable_property_map_tag;
 };
+}
 
 namespace mimir
 {
+
 inline boost::property_traits<IdIsIndexVertexIndex>::reference get(IdIsIndexVertexIndex, boost::property_traits<IdIsIndexVertexIndex>::key_type key)
 {
     return key;
@@ -151,14 +155,12 @@ strong_components(const TransitionSystem& g)
     const auto num_components = boost::strong_components(g, component_map_property, boost::vertex_index_map(IdIsIndexVertexIndex()));
     return std::make_pair(num_components, component_map);
 }
-}
 
-namespace mimir
-{
 /* Assert that the concepts are satisfied */
 BOOST_CONCEPT_ASSERT((boost::GraphConcept<StateSpace>) );
 BOOST_CONCEPT_ASSERT((boost::VertexListGraphConcept<StateSpace>) );
 BOOST_CONCEPT_ASSERT((boost::IncidenceGraphConcept<StateSpace>) );
+
 }
 
 #endif

--- a/include/mimir/datasets/boost_adapter.hpp
+++ b/include/mimir/datasets/boost_adapter.hpp
@@ -34,10 +34,12 @@
 namespace boost
 {
 
+/// A tag for a graph that is both a vertex list graph and an incidence graph.
 struct vertex_list_and_incidence_graph_tag : public vertex_list_graph_tag, public incidence_graph_tag
 {
 };
 
+/// Traits for a transition system that are needed for the boost graph library.
 template<mimir::IsTransitionSystem TransitionSystem>
 struct graph_traits<TransitionSystem>
 {
@@ -65,6 +67,9 @@ namespace mimir
 
 /* boost::VertexListGraph */
 
+/// @brief Get the vertices of the transition system.
+/// @param g the transition system.
+/// @return an iterator-range providing access to all the vertices in the transition system.
 template<IsTransitionSystem TransitionSystem>
 std::pair<typename boost::graph_traits<TransitionSystem>::vertex_iterator, typename boost::graph_traits<TransitionSystem>::vertex_iterator>
 vertices(const TransitionSystem& g)
@@ -76,6 +81,9 @@ vertices(const TransitionSystem& g)
     return std::make_pair(range.begin(), range.end());
 }
 
+/// @brief Get the number of vertices in the transition system.
+/// @param g the transition system.
+/// @return the number of vertices in the transition system.
 template<IsTransitionSystem TransitionSystem>
 boost::graph_traits<TransitionSystem>::vertices_size_type num_vertices(const TransitionSystem& g)
 {
@@ -84,6 +92,10 @@ boost::graph_traits<TransitionSystem>::vertices_size_type num_vertices(const Tra
 
 /* boost::IncidenceGraph */
 
+/// @brief Get the source state of a transition.
+/// @param e the transition.
+/// @param g the transition system.
+/// @return the source state of the transition.
 template<IsTransitionSystem TransitionSystem>
 typename boost::graph_traits<TransitionSystem>::vertex_descriptor source(const typename boost::graph_traits<TransitionSystem>::edge_descriptor& e,
                                                                          const TransitionSystem& g)
@@ -91,6 +103,10 @@ typename boost::graph_traits<TransitionSystem>::vertex_descriptor source(const t
     return g.get_transitions()[e].get_source_state();
 }
 
+/// @brief Get the target state of a transition.
+/// @param e the transition.
+/// @param g the transition system.
+/// @return the target state of the transition.
 template<IsTransitionSystem TransitionSystem>
 typename boost::graph_traits<TransitionSystem>::vertex_descriptor target(const typename boost::graph_traits<TransitionSystem>::edge_descriptor& e,
                                                                          const TransitionSystem& g)
@@ -98,6 +114,9 @@ typename boost::graph_traits<TransitionSystem>::vertex_descriptor target(const t
     return g.get_transitions()[e].get_target_state();
 }
 
+/// @brief Get the transitions of the transition system.
+/// @param g the transition system.
+/// @return an iterator-range providing access to all the forward transitions (i.e., the out edges) in the transition system.
 template<IsTransitionSystem TransitionSystem>
 std::pair<typename boost::graph_traits<TransitionSystem>::out_edge_iterator, typename boost::graph_traits<TransitionSystem>::out_edge_iterator>
 out_edges(typename boost::graph_traits<TransitionSystem>::vertex_descriptor const& u, const TransitionSystem& g)
@@ -105,6 +124,10 @@ out_edges(typename boost::graph_traits<TransitionSystem>::vertex_descriptor cons
     return { g.get_forward_transition_indices(u).begin(), g.get_forward_transition_indices(u).end() };
 }
 
+/// @brief Get the number of out edges of a state.
+/// @param u the state.
+/// @param g the transition system.
+/// @return the number of out edges of the state.
 template<IsTransitionSystem TransitionSystem>
 boost::graph_traits<TransitionSystem>::degree_size_type out_degree(typename boost::graph_traits<TransitionSystem>::vertex_descriptor const& u,
                                                                    const TransitionSystem& g)
@@ -119,6 +142,7 @@ boost::graph_traits<TransitionSystem>::degree_size_type out_degree(typename boos
 // To avoid storing a map of the size of the graph, we provide a custom index that just returns the key.
 namespace mimir
 {
+/// @brief A property map that maps a vertex to its index.
 struct IdIsIndexVertexIndex
 {
 };
@@ -126,6 +150,8 @@ struct IdIsIndexVertexIndex
 
 namespace boost
 {
+
+/// @brief Traits for the IdIsIndexVertexIndex property map, required for boost::strong_components.
 template<>
 struct property_traits<mimir::IdIsIndexVertexIndex>
 {
@@ -134,17 +160,23 @@ struct property_traits<mimir::IdIsIndexVertexIndex>
     using reference = mimir::StateIndex;
     using category = boost::readable_property_map_tag;
 };
+
 }
 
 namespace mimir
 {
 
+/// @brief Get the index of a state.
+/// @param key the state.
+/// @return the index of the state, which is just the input key.
 inline boost::property_traits<IdIsIndexVertexIndex>::reference get(IdIsIndexVertexIndex, boost::property_traits<IdIsIndexVertexIndex>::key_type key)
 {
     return key;
 }
 
-// Wrapper function for boost's strong_components algorithm.
+/// @brief Wrapper function for boost's strong_components algorithm.
+/// @param g the transition system.
+/// @return a pair of the number of strong components and a map from state to component.
 template<IsTransitionSystem TransitionSystem>
 std::pair<typename boost::graph_traits<TransitionSystem>::vertices_size_type,
           std::map<typename boost::graph_traits<TransitionSystem>::vertex_descriptor, typename boost::graph_traits<TransitionSystem>::vertices_size_type>>

--- a/include/mimir/datasets/boost_adapter.hpp
+++ b/include/mimir/datasets/boost_adapter.hpp
@@ -31,17 +31,6 @@
 #include <limits>
 #include <ranges>
 
-namespace mimir
-{
-struct StateIndexRangeView : std::ranges::iota_view<StateIndex, StateIndex>
-{
-    using std::ranges::iota_view<StateIndex, StateIndex>::iota_view;
-};
-}
-
-template<>
-inline constexpr bool std::ranges::enable_borrowed_range<mimir::StateIndexRangeView> = true;
-
 namespace boost
 {
 
@@ -60,7 +49,7 @@ struct graph_traits<TransitionSystem>
     using traversal_category = vertex_list_and_incidence_graph_tag;
     using edges_size_type = size_t;
     // boost::VertexListGraph
-    using vertex_iterator = std::ranges::iterator_t<mimir::StateIndexRangeView>;
+    using vertex_iterator = std::ranges::iterator_t<std::ranges::iota_view<vertex_descriptor, vertex_descriptor>>;
     using vertices_size_type = size_t;
     // boost::IncidenceGraph
     using out_edge_iterator = mimir::ForwardTransitionIndexIterator<typename TransitionSystem::TransitionType>::const_iterator;
@@ -80,9 +69,10 @@ template<IsTransitionSystem TransitionSystem>
 std::pair<typename boost::graph_traits<TransitionSystem>::vertex_iterator, typename boost::graph_traits<TransitionSystem>::vertex_iterator>
 vertices(const TransitionSystem& g)
 {
-    StateIndexRangeView range(0, g.get_num_states());
+    std::ranges::iota_view<typename boost::graph_traits<TransitionSystem>::vertex_descriptor, typename boost::graph_traits<TransitionSystem>::vertex_descriptor>
+        range(0, g.get_num_states());
     // Make sure we can return dangling iterators.
-    static_assert(std::ranges::borrowed_range<StateIndexRangeView>);
+    static_assert(std::ranges::borrowed_range<decltype(range)>);
     return std::make_pair(range.begin(), range.end());
 }
 

--- a/include/mimir/datasets/boost_adapter.hpp
+++ b/include/mimir/datasets/boost_adapter.hpp
@@ -18,6 +18,7 @@
 #ifndef MIMIR_DATASETS_BOOST_ADAPTER_HPP_
 #define MIMIR_DATASETS_BOOST_ADAPTER_HPP_
 
+#include "boost/graph/strong_components.hpp"
 #include "mimir/datasets/iterators.hpp"
 #include "mimir/datasets/state_space.hpp"
 #include "mimir/datasets/transition_interface.hpp"
@@ -147,6 +148,18 @@ namespace mimir
 inline boost::property_traits<IdIsIndexVertexIndex>::reference get(IdIsIndexVertexIndex, boost::property_traits<IdIsIndexVertexIndex>::key_type key)
 {
     return key;
+}
+
+// Wrapper function for boost's strong_components algorithm.
+template<IsTransitionSystem TransitionSystem>
+std::pair<typename boost::graph_traits<TransitionSystem>::vertices_size_type,
+          std::map<typename boost::graph_traits<TransitionSystem>::vertex_descriptor, typename boost::graph_traits<TransitionSystem>::vertices_size_type>>
+strong_components(const TransitionSystem& g)
+{
+    std::map<StateIndex, size_t> component_map;
+    boost::associative_property_map component_map_property(component_map);
+    const auto num_components = boost::strong_components(g, component_map_property, boost::vertex_index_map(IdIsIndexVertexIndex()));
+    return std::make_pair(num_components, component_map);
 }
 }
 

--- a/tests/unit/datasets/state_space.cpp
+++ b/tests/unit/datasets/state_space.cpp
@@ -1,6 +1,5 @@
 #include "mimir/datasets/state_space.hpp"
 
-#include "boost/graph/strong_components.hpp"
 #include "mimir/datasets/boost_adapter.hpp"
 
 #include <boost/graph/graph_concepts.hpp>
@@ -86,23 +85,18 @@ TEST(MimirTests, DatasetsStateSpaceStrongComponentsTest)
         const auto domain_file = fs::path(std::string(DATA_DIR) + "gripper/domain.pddl");
         const auto problem_file = fs::path(std::string(DATA_DIR) + "gripper/p-2-0.pddl");
         const auto state_space = StateSpace::create(domain_file, problem_file).value();
-        std::map<StateIndex, size_t> _component_map;
-        boost::associative_property_map component_map(_component_map);
-        const auto num_components = boost::strong_components(state_space, component_map, boost::vertex_index_map(IdIsIndexVertexIndex()));
-
+        const auto [num_components, component_map] = strong_components(state_space);
         EXPECT_EQ(num_components, 1);
         for (auto [it, last] = vertices(state_space); it != last; ++it)
         {
-            EXPECT_EQ(get(component_map, *it), 0);
+            EXPECT_EQ(component_map.at(*it), 0);
         }
     }
     {
         const auto domain_file = fs::path(std::string(DATA_DIR) + "spanner/domain.pddl");
         const auto problem_file = fs::path(std::string(DATA_DIR) + "spanner/test_problem.pddl");
         const auto state_space = StateSpace::create(domain_file, problem_file).value();
-        std::map<StateIndex, size_t> _component_map;
-        boost::associative_property_map component_map(_component_map);
-        const auto num_components = boost::strong_components(state_space, component_map, boost::vertex_index_map(IdIsIndexVertexIndex()));
+        const auto [num_components, component_map] = strong_components(state_space);
 
         // Each state should have its own component.
         EXPECT_EQ(num_components, num_vertices(state_space));
@@ -111,7 +105,7 @@ TEST(MimirTests, DatasetsStateSpaceStrongComponentsTest)
         std::map<size_t, size_t> num_states_per_component;
         for (auto [it, last] = vertices(state_space); it != last; ++it)
         {
-            num_states_per_component[get(component_map, *it)]++;
+            num_states_per_component[component_map.at(*it)]++;
         }
         for (const auto& [key, val] : num_states_per_component)
         {

--- a/tests/unit/datasets/state_space.cpp
+++ b/tests/unit/datasets/state_space.cpp
@@ -1,7 +1,10 @@
 #include "mimir/datasets/state_space.hpp"
 
+#include "boost/graph/strong_components.hpp"
 #include "mimir/datasets/boost_adapter.hpp"
 
+#include <boost/graph/graph_concepts.hpp>
+#include <boost/graph/properties.hpp>
 #include <gtest/gtest.h>
 
 namespace mimir::tests
@@ -75,5 +78,45 @@ TEST(MimirTests, DatasetsStateSpaceIncidenceGraphTest)
     // pick(ball1, rooma, right), pick(ball1, rooma, left), pick(ball2, rooma, right), pick(ball2, rooma, left)
     // move(rooma, rooma), move(rooma, roomb)
     EXPECT_EQ(out_degree(state_space.get_initial_state(), state_space), 6);
+}
+
+TEST(MimirTests, DatasetsStateSpaceStrongComponentsTest)
+{
+    {
+        const auto domain_file = fs::path(std::string(DATA_DIR) + "gripper/domain.pddl");
+        const auto problem_file = fs::path(std::string(DATA_DIR) + "gripper/p-2-0.pddl");
+        const auto state_space = StateSpace::create(domain_file, problem_file).value();
+        std::map<StateIndex, size_t> _component_map;
+        boost::associative_property_map component_map(_component_map);
+        const auto num_components = boost::strong_components(state_space, component_map, boost::vertex_index_map(IdIsIndexVertexIndex()));
+
+        EXPECT_EQ(num_components, 1);
+        for (auto [it, last] = vertices(state_space); it != last; ++it)
+        {
+            EXPECT_EQ(get(component_map, *it), 0);
+        }
+    }
+    {
+        const auto domain_file = fs::path(std::string(DATA_DIR) + "spanner/domain.pddl");
+        const auto problem_file = fs::path(std::string(DATA_DIR) + "spanner/test_problem.pddl");
+        const auto state_space = StateSpace::create(domain_file, problem_file).value();
+        std::map<StateIndex, size_t> _component_map;
+        boost::associative_property_map component_map(_component_map);
+        const auto num_components = boost::strong_components(state_space, component_map, boost::vertex_index_map(IdIsIndexVertexIndex()));
+
+        // Each state should have its own component.
+        EXPECT_EQ(num_components, num_vertices(state_space));
+
+        // Each component should only have one state.
+        std::map<size_t, size_t> num_states_per_component;
+        for (auto [it, last] = vertices(state_space); it != last; ++it)
+        {
+            num_states_per_component[get(component_map, *it)]++;
+        }
+        for (const auto& [key, val] : num_states_per_component)
+        {
+            EXPECT_EQ(val, 1);
+        }
+    }
 }
 }


### PR DESCRIPTION
Boost's strong_components requires some additional properties, which do not immediately follow from the documentation. Extend the adapter accordingly and also demonstrate in a test how the strong components can be computed.