### PR TITLE
Feat/add fmt

### DIFF
--- a/.github/workflows/integrationtests.yml
+++ b/.github/workflows/integrationtests.yml
@@ -1,9 +1,6 @@
 name: Integration Tests
 
-on:
-  push:
-    branches:
-      - main
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,9 +1,6 @@
 name: Googletest Unit Tests
 
-on:
-  push:
-    branches:
-      - main
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .vscode/settings.json
 .vscode/tasks.json
 
+.idea
+cmake-build-*
+
 # Python build artefacts
 __pycache__
 MANIFEST.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ else()
         set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
     endif()
     # TODO: Add -Wextra and fix all warnings
+    if(COMPILER_ID MATCHES "GNU")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto=auto")
+    endif ()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -DNDEBUG")
     set(CMAKE_CXX_FLAGS_PROFILING "-O3 -Wall -pg")
@@ -107,6 +110,11 @@ if(Nauty_FOUND)
   message(STATUS "Found Nauty: ${NAUTY_LIBRARY} ${NAUTY_INCLUDE_DIR}")
 endif()
 
+find_package(fmt REQUIRED)
+if(fmt_FOUND)
+  include_directories(${fmt_INCLUDE_DIRS})
+  message(STATUS "Found fmt: ${fmt_DIR} (found version ${fmt_VERSION})")
+endif()
 
 ##############################################################
 # Add library and executable targets

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -22,6 +22,7 @@ set(BUILD_TYPE ${CMAKE_BUILD_TYPE})
 
 add_subdirectory(benchmark)
 add_subdirectory(boost)
+add_subdirectory(fmt)
 add_subdirectory(googletest)
 add_subdirectory(loki)
 add_subdirectory(nauty)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -15,6 +15,10 @@ endif()
 # Pass the build type to subdirectories
 set(BUILD_TYPE ${CMAKE_BUILD_TYPE})
 
+if(COMPILER_ID MATCHES "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto=auto")
+endif ()
+
 
 ##############################################################
 # Add subprojects

--- a/dependencies/benchmark/CMakeLists.txt
+++ b/dependencies/benchmark/CMakeLists.txt
@@ -3,22 +3,35 @@ project(InstallBenchmark)
 
 include(ExternalProject)
 
-list(APPEND CMAKE_ARGS
-    -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
-    -DCMAKE_BUILD_TYPE=Release
-    -DBENCHMARK_ENABLE_GTEST_TESTS=OFF
-)
+message(STATUS "Dependency \"benchmark\"...")
 
-message(STATUS "Preparing external project \"benchmark\" with args:")
-foreach(CMAKE_ARG ${CMAKE_ARGS})
-    message(STATUS "-- ${CMAKE_ARG}")
-endforeach()
+find_package(benchmark QUIET PATHS ${CMAKE_INSTALL_PREFIX} NO_DEFAULT_PATH)
 
-ExternalProject_Add(
-    benchmark
-    GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG v1.8.3
-    PREFIX ${CMAKE_BINARY_DIR}/benchmark
-    CMAKE_ARGS ${CMAKE_ARGS}
-)
+if (NOT benchmark_FOUND)
+
+    list(APPEND CMAKE_ARGS
+            -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
+            -DCMAKE_BUILD_TYPE=Release
+            -DBENCHMARK_ENABLE_GTEST_TESTS=OFF
+    )
+
+    message(STATUS "Preparing external project \"benchmark\" with args:")
+    foreach(CMAKE_ARG ${CMAKE_ARGS})
+        message(STATUS "-- ${CMAKE_ARG}")
+    endforeach()
+
+    ExternalProject_Add(
+            benchmark
+            GIT_REPOSITORY https://github.com/google/benchmark.git
+            GIT_TAG v1.8.3
+            PREFIX ${CMAKE_BINARY_DIR}/benchmark
+            CMAKE_ARGS ${CMAKE_ARGS}
+    )
+
+
+else()
+    message(STATUS "benchmark is already installed.")
+endif()
+
+
 

--- a/dependencies/boost/CMakeLists.txt
+++ b/dependencies/boost/CMakeLists.txt
@@ -3,15 +3,28 @@ project(InstallBoost)
 
 include(ExternalProject)
 
-message(STATUS "Preparing external project \"boost\":")
+message(STATUS "Dependency \"boost\"...")
 
-# We need to build boost for cmake support
-ExternalProject_Add(
-    boost
-    URL https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.gz
-    PREFIX ${CMAKE_BINARY_DIR}/boost
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./bootstrap.sh --prefix=<INSTALL_DIR> --without-libraries=python
-    BUILD_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./b2 link=static cxxflags=-fPIC cflags=-fPIC
-    INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./b2 install
-    INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
-)
+# Attempt to find the installed library
+find_package(Boost QUIET PATHS ${CMAKE_INSTALL_PREFIX} NO_DEFAULT_PATH)
+
+if (NOT Boost_FOUND)
+
+    message(STATUS "Preparing external project \"boost\":")
+
+    # We need to build boost for cmake support
+    ExternalProject_Add(
+            boost
+            URL https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.gz
+            PREFIX ${CMAKE_BINARY_DIR}/boost
+            CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./bootstrap.sh --prefix=<INSTALL_DIR> --without-libraries=python
+            BUILD_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./b2 link=static cxxflags=-fPIC cflags=-fPIC
+            INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./b2 install
+            INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+    )
+else()
+    message(STATUS "Boost is already installed.")
+endif()
+
+
+

--- a/dependencies/fmt/CMakeLists.txt
+++ b/dependencies/fmt/CMakeLists.txt
@@ -3,17 +3,29 @@ project(InstallFMT)
 
 include(ExternalProject)
 
-message(STATUS "Preparing external project \"fmt\" with args:")
-foreach (CMAKE_ARG ${CMAKE_ARGS})
-    message(STATUS "-- ${CMAKE_ARG}")
-endforeach ()
 
-ExternalProject_Add(
-        fmt
-        GIT_REPOSITORY https://github.com/fmtlib/fmt
-        GIT_TAG 11.0.2
-        PREFIX ${CMAKE_BINARY_DIR}/fmt
-        CMAKE_ARGS ${CMAKE_ARGS}
-)
+message(STATUS "Dependency \"fmt\"...")
 
+# Attempt to find the installed googletest library
+find_package(fmt QUIET PATHS ${CMAKE_INSTALL_PREFIX} NO_DEFAULT_PATH)
+
+if (NOT fmt_FOUND)
+    list(APPEND CMAKE_ARGS
+            -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
+    )
+    message(STATUS "Preparing external project \"fmt\" with args:")
+    foreach (CMAKE_ARG ${CMAKE_ARGS})
+        message(STATUS "-- ${CMAKE_ARG}")
+    endforeach ()
+
+    ExternalProject_Add(
+            fmt
+            GIT_REPOSITORY https://github.com/fmtlib/fmt
+            GIT_TAG 11.0.2
+            PREFIX ${CMAKE_BINARY_DIR}/fmt
+            CMAKE_ARGS ${CMAKE_ARGS}
+    )
+else ()
+    message(STATUS "googletest is already installed.")
+endif ()
 

--- a/dependencies/fmt/CMakeLists.txt
+++ b/dependencies/fmt/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.21)
+project(InstallFMT)
+
+include(ExternalProject)
+
+message(STATUS "Preparing external project \"fmt\" with args:")
+foreach (CMAKE_ARG ${CMAKE_ARGS})
+    message(STATUS "-- ${CMAKE_ARG}")
+endforeach ()
+
+ExternalProject_Add(
+        fmt
+        GIT_REPOSITORY https://github.com/fmtlib/fmt
+        GIT_TAG 11.0.2
+        PREFIX ${CMAKE_BINARY_DIR}/fmt
+        CMAKE_ARGS ${CMAKE_ARGS}
+)
+
+

--- a/dependencies/googletest/CMakeLists.txt
+++ b/dependencies/googletest/CMakeLists.txt
@@ -3,19 +3,29 @@ project(InstallGoogletest)
 
 include(ExternalProject)
 
-list(APPEND CMAKE_ARGS
-    -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
-)
+message(STATUS "Dependency \"GTest\"...")
 
-message(STATUS "Preparing external project \"googletest\" with args:")
-foreach(CMAKE_ARG ${CMAKE_ARGS})
-    message(STATUS "-- ${CMAKE_ARG}")
-endforeach()
+# Attempt to find the installed googletest library
+find_package(GTest QUIET PATHS ${CMAKE_INSTALL_PREFIX} NO_DEFAULT_PATH)
 
-ExternalProject_Add(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.12.1
-    PREFIX ${CMAKE_BINARY_DIR}/googletest
-    CMAKE_ARGS ${CMAKE_ARGS}
-)
+if (NOT GTest_FOUND)
+
+    list(APPEND CMAKE_ARGS
+            -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
+    )
+
+    message(STATUS "Preparing external project \"googletest\" with args:")
+    foreach (CMAKE_ARG ${CMAKE_ARGS})
+        message(STATUS "-- ${CMAKE_ARG}")
+    endforeach ()
+
+    ExternalProject_Add(
+            googletest
+            GIT_REPOSITORY https://github.com/google/googletest.git
+            GIT_TAG release-1.12.1
+            PREFIX ${CMAKE_BINARY_DIR}/googletest
+            CMAKE_ARGS ${CMAKE_ARGS}
+    )
+else ()
+    message(STATUS "googletest is already installed.")
+endif ()

--- a/dependencies/loki/CMakeLists.txt
+++ b/dependencies/loki/CMakeLists.txt
@@ -3,26 +3,32 @@ project(InstallLoki)
 
 include(ExternalProject)
 
-if(NOT DEFINED BUILD_TYPE)
-    set(BUILD_TYPE "Release")
+message(STATUS "Dependency \"loki\"...")
+
+# Attempt to find the installed loki library
+find_package(loki QUIET PATHS ${CMAKE_INSTALL_PREFIX} NO_DEFAULT_PATH)
+
+if (NOT loki_FOUND)
+
+
+    list(APPEND CMAKE_ARGS
+            -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+            -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+            -DCMAKE_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}
+    )
+
+    message(STATUS "Preparing external project \"loki\" with args:")
+    foreach(CMAKE_ARG ${CMAKE_ARGS})
+        message(STATUS "-- ${CMAKE_ARG}")
+    endforeach()
+    ExternalProject_Add(
+            loki
+            GIT_REPOSITORY https://github.com/drexlerd/Loki.git
+            GIT_TAG v0.0.5
+            PREFIX ${CMAKE_BINARY_DIR}/loki
+            DEPENDS boost
+            CMAKE_ARGS ${CMAKE_ARGS}
+    )
+else()
+    message(STATUS "loki is already installed.")
 endif()
-
-list(APPEND CMAKE_ARGS
-    -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
-    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-    -DCMAKE_PREFIX_PATH=${CMAKE_INSTALL_PREFIX}
-)
-
-message(STATUS "Preparing external project \"loki\" with args:")
-foreach(CMAKE_ARG ${CMAKE_ARGS})
-    message(STATUS "-- ${CMAKE_ARG}")
-endforeach()
-
-ExternalProject_Add(
-    loki
-    GIT_REPOSITORY https://github.com/drexlerd/Loki.git
-    GIT_TAG v0.0.5
-    PREFIX ${CMAKE_BINARY_DIR}/loki
-    DEPENDS boost
-    CMAKE_ARGS ${CMAKE_ARGS}
-)

--- a/dependencies/nauty/CMakeLists.txt
+++ b/dependencies/nauty/CMakeLists.txt
@@ -3,15 +3,25 @@ project(InstallNauty)
 
 include(ExternalProject)
 
-message(STATUS "Preparing external project \"nauty\":")
+message(STATUS "Dependency \"nauty\"...")
 
-# We need to build nauty for cmake support
-ExternalProject_Add(
-    nauty
-    URL https://users.cecs.anu.edu.au/~bdm/nauty/nauty2_8_8.tar.gz
-    PREFIX ${CMAKE_BINARY_DIR}/nauty
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./configure --prefix=<INSTALL_DIR> CFLAGS=-fPIC --enable-tls
-    BUILD_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make
-    INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make install
-    INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
-)
+find_package(Nauty QUIET PATHS ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX}/include ${CMAKE_INSTALL_PREFIX}/lib NO_DEFAULT_PATH)
+
+if (NOT Nauty_FOUND)
+
+    message(STATUS "Preparing external project \"nauty\".")
+
+    # We need to build nauty for cmake support
+    ExternalProject_Add(
+            nauty
+            URL https://users.cecs.anu.edu.au/~bdm/nauty/nauty2_8_8.tar.gz
+            PREFIX ${CMAKE_BINARY_DIR}/nauty
+            CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> ./configure --prefix=<INSTALL_DIR> CFLAGS=-fPIC --enable-tls
+            BUILD_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make
+            INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> make install
+            INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+    )
+else ()
+    message(STATUS "nauty is already installed.")
+endif ()
+

--- a/dependencies/pybind11/CMakeLists.txt
+++ b/dependencies/pybind11/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(InstallGoogletest)
+project(InstallPybind11)
 
 include(ExternalProject)
 

--- a/dependencies/pybind11/CMakeLists.txt
+++ b/dependencies/pybind11/CMakeLists.txt
@@ -3,20 +3,32 @@ project(InstallGoogletest)
 
 include(ExternalProject)
 
-list(APPEND CMAKE_ARGS
-    -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
+message(STATUS "Dependency \"pybind11\"...")
+
+# Attempt to find the installed library
+find_package(pybind11 QUIET PATHS ${CMAKE_INSTALL_PREFIX} NO_DEFAULT_PATH)
+
+if (NOT pybind11_FOUND)
+    list(APPEND CMAKE_ARGS
+            -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
     )
 
-message(STATUS "Preparing external project \"pybind11\" with args:")
-foreach(CMAKE_ARG ${CMAKE_ARGS})
-    message(STATUS "-- ${CMAKE_ARG}")
-endforeach()
+    message(STATUS "Preparing external project \"pybind11\" with args:")
+    foreach(CMAKE_ARG ${CMAKE_ARGS})
+        message(STATUS "-- ${CMAKE_ARG}")
+    endforeach()
 
-ExternalProject_Add(
-    pybind11
-    GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG v2.11.1
-    PREFIX ${CMAKE_BINARY_DIR}/pybind11
-    CMAKE_ARGS ${CMAKE_ARGS}
-)
+
+    # If the library is not found, use ExternalProject_Add to download and build it
+    ExternalProject_Add(
+            pybind11
+            GIT_REPOSITORY https://github.com/pybind/pybind11.git
+            GIT_TAG v2.11.1
+            PREFIX ${CMAKE_BINARY_DIR}/pybind11
+            CMAKE_ARGS ${CMAKE_ARGS}
+    )
+else()
+    message(STATUS "pybind11 is already installed.")
+endif()
+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "pybind11_stubgen",
     "wheel",
     "cmake>=3.21",
+    "ninja",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(mimir::core ALIAS core)
 target_link_libraries(core loki::parsers)
 target_link_libraries(core Nauty::Nauty)
 target_link_libraries(core Boost::iostreams ZLIB::ZLIB)
+target_link_libraries(core fmt::fmt)
 
 # Use include depending on building or using from installed location
 target_include_directories(core


### PR DESCRIPTION
Hi guys,

this PR would add:

-  [fmt](https://github.com/fmtlib/fmt) to the project as a dependency which makes formatting and outputting to the console a lot simpler and intuitive (Python-like string formatting).
-  checks for existing installations of the dependencies within the dependencies folder to avoid redownloading and rebuilding them; as well for the pip installation of pymimir which now copies existing installations in the dependencies over to the temp dir (makes development with successive pip installations faster, irrelevant for PyPI packaging steps)
- Ninja as the build generator in the python packaging step, as it is simply much faster than the platform defaults (e.g. auto-parallelism).
- Workflows (Unit/Integration) are also enabled for all branches and PRs in this branch. I don't quite see a reason not to, you could set PRs to require permission to run the workflows if you want. Easy to undo if you don't like it.

Let me know what you think! :)