### PR TITLE
add type hints for generic atoms, predicates, literals, etc...

### DIFF
--- a/python/src/pymimir/__init__.py
+++ b/python/src/pymimir/__init__.py
@@ -182,3 +182,6 @@ from _pymimir import (
     compute_sorted_vertex_colors,
     create_object_graph
 )
+
+from .hints import *
+

--- a/python/src/pymimir/hints.py
+++ b/python/src/pymimir/hints.py
@@ -1,0 +1,56 @@
+# type hints:
+from typing import Union
+
+# import the necessary classes:
+from pyimir import (
+    StaticAtom,
+    FluentAtom,
+    DerivedAtom,
+    StaticGroundAtom,
+    FluentGroundAtom,
+    DerivedGroundAtom,
+    StaticLiteral,
+    FluentLiteral,
+    DerivedLiteral,
+    StaticGroundLiteral,
+    FluentGroundLiteral,
+    DerivedGroundLiteral,
+    StaticPredicate,
+    FluentPredicate,
+    DerivedPredicate,
+)
+
+# Define the type hint for the Atom class:
+Atom = Union[
+    StaticAtom,
+    FluentAtom,
+    DerivedAtom,
+]
+GroundAtom = Union[
+    StaticGroundAtom,
+    FluentGroundAtom,
+    DerivedGroundAtom,
+]
+Literal = Union[
+    StaticLiteral,
+    FluentLiteral,
+    DerivedLiteral,
+]
+GroundLiteral = Union[
+    StaticGroundLiteral,
+    FluentGroundLiteral,
+    DerivedGroundLiteral,
+]
+Predicate = Union[
+    StaticPredicate,
+    FluentPredicate,
+    DerivedPredicate,
+]
+
+__all__ = [
+    "Atom",
+    "GroundAtom",
+    "Literal",
+    "GroundLiteral",
+    "Predicate",
+]


### PR DESCRIPTION
Hi,

it is often quite helpful to be able to annotate expected parameter types with just 'Atom' for example when one does not care whether said atom is static, fluent, or derived. Likewise, for other sub-types like Literal, Predicate etc.

The simplest way to do so are the type hints I added in this PR.

The downside of type hints are that they do not account for e.g. `isinstance` checks.

Another way would be to make a base class for each (static polymorphism to dispatch methods), and then expose an ABC version perhaps with pybind11. I haven't thought through this approach fully yet though. 

This PR is more of a discussion push if you want, unless it provides an adequate solution already :)