### PR TITLE
Saner API for state retrieval

### DIFF
--- a/include/mimir/datasets/state_space.hpp
+++ b/include/mimir/datasets/state_space.hpp
@@ -163,7 +163,10 @@ public:
 
     /* States */
     State get_state(Index state) const;
-    const StateVertex& get_state(Index state) const;
+    auto get_states_view() const
+    {
+        return std::views::transform(m_graph.get_vertices(), [&](const auto& vertex) { return mimir::get_state(vertex); });
+    }
     const StateVertexList& get_state_vertices() const;
     const StateVertex& get_state_vertex(Index state) const;
     template<IsTraversalDirection Direction>

--- a/include/mimir/datasets/state_space.hpp
+++ b/include/mimir/datasets/state_space.hpp
@@ -162,8 +162,10 @@ public:
     const GraphType& get_graph() const;
 
     /* States */
-    const StateVertexList& get_states() const;
+    State get_state(Index state) const;
     const StateVertex& get_state(Index state) const;
+    const StateVertexList& get_state_vertices() const;
+    const StateVertex& get_state_vertex(Index state) const;
     template<IsTraversalDirection Direction>
     std::ranges::subrange<AdjacentVertexConstIteratorType<Direction>> get_adjacent_states(Index state) const;
     template<IsTraversalDirection Direction>

--- a/python/src/pymimir/bindings.cpp
+++ b/python/src/pymimir/bindings.cpp
@@ -1620,8 +1620,48 @@ void init_pymimir(py::module_& m)
         .def("get_state_vertices", &StateSpace::get_state_vertices, py::return_value_policy::reference_internal)
         .def("get_state_index", &StateSpace::get_state_index, py::arg("state"))
         .def("get_initial_state_index", &StateSpace::get_initial_state)
+        .def(
+            "get_initial_state",
+            [](const StateSpace& self) { return get_state(self.get_state_vertex(self.get_initial_state())); },
+            py::return_value_policy::reference_internal)
         .def("get_goal_state_indices", &StateSpace::get_goal_states, py::return_value_policy::reference_internal)
+        .def("get_goal_states",
+             [](py::object self)
+             {
+                 const auto& space = py::cast<const StateSpace&>(self);
+                 py::list goal_states;
+                 for (auto goal_state :
+                      space.get_goal_states() | std::views::transform([&](const auto& index) { return get_state(space.get_state_vertex(index)); }))
+                 {
+                     auto py_state = py::cast(goal_state);
+                     if (!py_state)
+                     {
+                         throw py::error_already_set();
+                     }
+                     py::detail::keep_alive_impl(self, py_state);
+                     goal_states.append(py_state);
+                 }
+                 return goal_states;
+             })
         .def("get_deadend_state_indices", &StateSpace::get_deadend_states, py::return_value_policy::reference_internal)
+        .def("get_deadend_states",
+             [](py::object self)
+             {
+                 const auto& space = py::cast<const StateSpace&>(self);
+                 py::list deadend_states;
+                 for (auto deadend_state :
+                      space.get_deadend_states() | std::views::transform([&](const auto& index) { return get_state(space.get_state_vertex(index)); }))
+                 {
+                     auto py_state = py::cast(deadend_state);
+                     if (!py_state)
+                     {
+                         throw py::error_already_set();
+                     }
+                     py::detail::keep_alive_impl(self, py_state);
+                     deadend_states.append(py_state);
+                 }
+                 return deadend_states;
+             })
         .def(
             "get_forward_adjacent_states",
             [](const StateSpace& self, Index state)

--- a/python/src/pymimir/bindings.cpp
+++ b/python/src/pymimir/bindings.cpp
@@ -1501,7 +1501,7 @@ void init_pymimir(py::module_& m)
         .def("__eq__", &StateVertex::operator==)
         .def("__hash__", [](const StateVertex& self) { return std::hash<StateVertex>()(self); })
         .def("get_index", &StateVertex::get_index)
-        .def("get_state_vertex", [](const StateVertex& self) { return get_state(self); }, py::keep_alive<0, 1>());
+        .def("get_state", [](const StateVertex& self) { return get_state(self); }, py::keep_alive<0, 1>());
 
     // GroundActionEdge
     py::class_<GroundActionEdge>(m, "GroundActionEdge")  //

--- a/python/src/pymimir/bindings.cpp
+++ b/python/src/pymimir/bindings.cpp
@@ -1619,9 +1619,9 @@ void init_pymimir(py::module_& m)
         .def("get_state_vertex", &StateSpace::get_state_vertex, py::arg("state_index"), py::return_value_policy::reference_internal)
         .def("get_state_vertices", &StateSpace::get_state_vertices, py::return_value_policy::reference_internal)
         .def("get_state_index", &StateSpace::get_state_index, py::arg("state"))
-        .def("get_initial_state", &StateSpace::get_initial_state)
-        .def("get_goal_states", &StateSpace::get_goal_states, py::return_value_policy::reference_internal)
-        .def("get_deadend_states", &StateSpace::get_deadend_states, py::return_value_policy::reference_internal)
+        .def("get_initial_state_index", &StateSpace::get_initial_state)
+        .def("get_goal_state_indices", &StateSpace::get_goal_states, py::return_value_policy::reference_internal)
+        .def("get_deadend_state_indices", &StateSpace::get_deadend_states, py::return_value_policy::reference_internal)
         .def(
             "get_forward_adjacent_states",
             [](const StateSpace& self, Index state)

--- a/python/src/pymimir/bindings.cpp
+++ b/python/src/pymimir/bindings.cpp
@@ -1627,26 +1627,17 @@ void init_pymimir(py::module_& m)
             py::return_value_policy::reference_internal)
         .def("get_goal_state_indices", &StateSpace::get_goal_states, py::return_value_policy::reference_internal)
         .def("get_goal_states",
-             [](const py::object& self)
+             [](const StateSpace& self)
              {
-                 const auto& space = py::cast<const StateSpace&>(self);
-                 py::list goal_states(space.get_goal_states().size());
-                 insert_into_list(self,
-                                  goal_states,
-                                  space.get_goal_states() | std::views::transform([&](const auto& index) { return get_state(space.get_state_vertex(index)); }));
-                 return goal_states;
+                 auto view = self.get_goal_states() | std::views::transform([&](const auto& index) { return get_state(self.get_state_vertex(index)); });
+                 return StateList(view.begin(), view.end());
              })
         .def("get_deadend_state_indices", &StateSpace::get_deadend_states, py::return_value_policy::reference_internal)
         .def("get_deadend_states",
-             [](const py::object& self)
+             [](const StateSpace& self)
              {
-                 const auto& space = py::cast<const StateSpace&>(self);
-                 py::list deadend_states(space.get_deadend_states().size());
-                 insert_into_list(self,
-                                  deadend_states,
-                                  space.get_deadend_states()
-                                      | std::views::transform([&](const auto& index) { return get_state(space.get_state_vertex(index)); }));
-                 return deadend_states;
+                 auto view = self.get_deadend_states() | std::views::transform([&](const auto& index) { return get_state(self.get_state_vertex(index)); });
+                 return StateList(view.begin(), view.end());
              })
         .def(
             "get_forward_adjacent_states",

--- a/python/src/pymimir/bindings.cpp
+++ b/python/src/pymimir/bindings.cpp
@@ -1114,13 +1114,13 @@ void init_pymimir(py::module_& m)
                  ss << ")";
                  return ss.str();
              })
-        .def("get_fluent_atoms",
+        .def("get_fluent_atom_indices",
              [](State self)
              {
                  auto atoms = self.get_atoms<Fluent>();
                  return std::vector<size_t>(atoms.begin(), atoms.end());
              })
-        .def("get_derived_atoms",
+        .def("get_derived_atom_indices",
              [](State self)
              {
                  auto atoms = self.get_atoms<Derived>();

--- a/python/src/pymimir/bindings.cpp
+++ b/python/src/pymimir/bindings.cpp
@@ -1501,10 +1501,7 @@ void init_pymimir(py::module_& m)
         .def("__eq__", &StateVertex::operator==)
         .def("__hash__", [](const StateVertex& self) { return std::hash<StateVertex>()(self); })
         .def("get_index", &StateVertex::get_index)
-        .def(
-            "get_state",
-            [](const StateVertex& self) { return get_state(self); },
-            py::keep_alive<0, 1>());
+        .def("get_state_vertex", [](const StateVertex& self) { return get_state(self); }, py::keep_alive<0, 1>());
 
     // GroundActionEdge
     py::class_<GroundActionEdge>(m, "GroundActionEdge")  //
@@ -1612,8 +1609,15 @@ void init_pymimir(py::module_& m)
         .def("get_pddl_factories", &StateSpace::get_pddl_factories)
         .def("get_aag", &StateSpace::get_aag)
         .def("get_ssg", &StateSpace::get_ssg)
-        .def("get_state", &StateSpace::get_state, py::arg("state_index"))
-        .def("get_states", &StateSpace::get_states, py::return_value_policy::reference_internal)
+        .def("get_state", &StateSpace::get_state, py::arg("state_index"), py::return_value_policy::reference_internal)
+        .def("get_states_iter",
+             [](const StateSpace& self)
+             {
+                 auto view = self.get_states_view();
+                 return py::make_iterator(view.begin(), view.end(), py::keep_alive<0, 1>());
+             })
+        .def("get_state_vertex", &StateSpace::get_state_vertex, py::arg("state_index"), py::return_value_policy::reference_internal)
+        .def("get_state_vertices", &StateSpace::get_state_vertices, py::return_value_policy::reference_internal)
         .def("get_state_index", &StateSpace::get_state_index, py::arg("state"))
         .def("get_initial_state", &StateSpace::get_initial_state)
         .def("get_goal_states", &StateSpace::get_goal_states, py::return_value_policy::reference_internal)
@@ -1757,7 +1761,7 @@ void init_pymimir(py::module_& m)
     py::class_<FaithfulAbstractStateVertex>(m, "FaithfulAbstractStateVertex")
         .def("get_index", &FaithfulAbstractStateVertex::get_index)
         .def(
-            "get_states",
+            "get_state_vertices",
             [](const FaithfulAbstractStateVertex& self) { return std::vector<State>(get_states(self).begin(), get_states(self).end()); },
             py::keep_alive<0, 1>())
         .def(
@@ -1827,7 +1831,7 @@ void init_pymimir(py::module_& m)
         .def("get_aag", &FaithfulAbstraction::get_aag)
         .def("get_ssg", &FaithfulAbstraction::get_ssg)
         .def("get_abstract_state_index", &FaithfulAbstraction::get_abstract_state_index, py::arg("state"))
-        .def("get_states", &FaithfulAbstraction::get_states, py::return_value_policy::reference_internal)
+        .def("get_state_vertices", &FaithfulAbstraction::get_states, py::return_value_policy::reference_internal)
         .def("get_concrete_to_abstract_state", &FaithfulAbstraction::get_concrete_to_abstract_state, py::return_value_policy::reference_internal)
         .def("get_initial_state", &FaithfulAbstraction::get_initial_state)
         .def("get_goal_states", &FaithfulAbstraction::get_goal_states, py::return_value_policy::reference_internal)
@@ -1967,7 +1971,7 @@ void init_pymimir(py::module_& m)
         .def("get_abstractions", &GlobalFaithfulAbstraction::get_abstractions, py::return_value_policy::reference_internal)
         .def("get_abstract_state_index", py::overload_cast<State>(&GlobalFaithfulAbstraction::get_abstract_state_index, py::const_), py::arg("state"))
         .def("get_abstract_state_index", py::overload_cast<Index>(&GlobalFaithfulAbstraction::get_abstract_state_index, py::const_), py::arg("state_index"))
-        .def("get_states", &GlobalFaithfulAbstraction::get_states, py::return_value_policy::reference_internal)
+        .def("get_state_vertices", &GlobalFaithfulAbstraction::get_states, py::return_value_policy::reference_internal)
         .def("get_concrete_to_abstract_state", &GlobalFaithfulAbstraction::get_concrete_to_abstract_state, py::return_value_policy::reference_internal)
         .def("get_global_state_index_to_state_index",
              &GlobalFaithfulAbstraction::get_global_state_index_to_state_index,
@@ -2144,10 +2148,7 @@ void init_pymimir(py::module_& m)
     py::class_<TupleGraphVertex>(m, "TupleGraphVertex")  //
         .def("get_index", &TupleGraphVertex::get_index)
         .def("get_tuple_index", &TupleGraphVertex::get_tuple_index)
-        .def(
-            "get_states",
-            [](const TupleGraphVertex& self) { return StateList(self.get_states()); },
-            py::keep_alive<0, 1>());
+        .def("get_state_vertices", [](const TupleGraphVertex& self) { return StateList(self.get_states()); }, py::keep_alive<0, 1>());
     bind_const_span<std::span<const TupleGraphVertex>>(m, "TupleGraphVertexSpan");
     bind_const_index_grouped_vector<IndexGroupedVector<const TupleGraphVertex>>(m, "TupleGraphVertexIndexGroupedVector");
 

--- a/src/datasets/state_space.cpp
+++ b/src/datasets/state_space.cpp
@@ -315,9 +315,9 @@ const std::shared_ptr<StateRepository>& StateSpace::get_ssg() const { return m_s
 const typename StateSpace::GraphType& StateSpace::get_graph() const { return m_graph; }
 
 /* States */
-const StateVertexList& StateSpace::get_states() const { return m_graph.get_vertices(); }
+const StateVertexList& StateSpace::get_state_vertices() const { return m_graph.get_vertices(); }
 
-const StateVertex& StateSpace::get_state(Index state) const { return m_graph.get_vertices().at(state); }
+const StateVertex& StateSpace::get_state_vertex(Index state) const { return m_graph.get_vertices().at(state); }
 
 template<IsTraversalDirection Direction>
 std::ranges::subrange<StateSpace::AdjacentVertexConstIteratorType<Direction>> StateSpace::get_adjacent_states(Index state) const
@@ -406,6 +406,11 @@ Index StateSpace::sample_state_with_goal_distance(ContinuousCost goal_distance) 
     const auto index = std::rand() % static_cast<int>(states.size());
     return states.at(index);
 }
+
+State StateSpace::get_state(Index state) const {
+    return mimir::get_state(m_graph.get_vertices().at(state));
+}
+
 
 /**
  * Pretty printing

--- a/src/search/heuristics/hstar.cpp
+++ b/src/search/heuristics/hstar.cpp
@@ -35,7 +35,7 @@ HStarHeuristic::HStarHeuristic(Problem problem,
     auto state_space = StateSpace::create(problem, pddl_factories, applicable_action_generator, state_repository, state_space_options).value();
     for (size_t state_index = 0; state_index < state_space.get_num_states(); ++state_index)
     {
-        m_estimates.emplace(get_state(state_space.get_state(state_index)), state_space.get_goal_distance(state_index));
+        m_estimates.emplace(get_state(state_space.get_state_vertex(state_index)), state_space.get_goal_distance(state_index));
     }
 }
 

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -4,6 +4,9 @@ find_package(GTest)
 
 find_package(pybind11)
 
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
 add_executable(pymimir_tests
         main_tests.cpp
         test_bindings.cpp


### PR DESCRIPTION
Hi,

I have been working with the code for the past few days and certain API decisions are problematic at the moment. Consider this example:
```
def get_init_state():
    parser = mi.PDDLParser(path_to_domain, path_to_problem)
    factory = parser.get_pddl_factories()
    domain = parser.get_domain()
    problem = parser.get_problem()
    aag = mi.GroundedApplicableActionGenerator(problem, factory)
    space = mi.StateSpace.create(problem, factory, aag, mi.StateRepository(aag))
    
    state = space.get_initial_state()  # this is not a state
    state = space.get_state(state)  # this is not a state either yet
    state = state.get_state()  # now it is a state
    return state
```
Incidentally, the above function is also currently a segfault trigger, since the `StateVertex` returned by the `StateSpace` does not keep the `StateSpace` alive, while the `State` only keeps the `StateVertex` alive.

Aside from the segfault, similar issues arise when querying for atoms in a state: `state.get_fluent_atoms()` does not, in fact,  return atoms, it returns atom indices which need to be given to fluent atom lists to receive the actual atoms. 

Since the current API is confusing, I would like to change the bindings to reflect what you receive now. This PR addresses this as such:
- (fixes segfault issue)
- a `State` object now returns atom indices from functions `get_fluent_atom_indices` (and likewise named equivalents).
- StateSpace `get_state` --> `get_state_vertex` and likewise for multiple. I also added actual `get_state` functions that prevent the need to go through a vertex.

With my changes, the above snippet would then read:
```
def get_init_state():
    parser = mi.PDDLParser(path_to_domain, path_to_problem)
    factory = parser.get_pddl_factories()
    domain = parser.get_domain()
    problem = parser.get_problem()
    aag = mi.GroundedApplicableActionGenerator(problem, factory)
    space = mi.StateSpace.create(problem, factory, aag, mi.StateRepository(aag))
    
    state_index = space.get_initial_state_index()
    state_vertex = space.get_state_vertex(state_index)
    state = state_vertex.get_state()

# alternatively

    state = space.get_initial_state()  # now returns an actual State object
    return state
```

Let me know what you think about these changes or if you want something changed. 