### PR TITLE
turn variables in __all__ to strings for dataset

### DIFF
--- a/python/src/pymimir/advanced/datasets/__init__.py
+++ b/python/src/pymimir/advanced/datasets/__init__.py
@@ -73,44 +73,36 @@ from pymimir.pymimir.advanced.datasets import (
 
 __all__ = [
     # StateSpace
-    ProblemVertex,
-    ProblemEdge,
-    StaticProblemGraph,
-    ImmutableStaticProblemGraph,
-    ForwardStaticProblemGraph,
-    BidirectionalStaticProblemGraph,
-
-    StateSpace,
-    StateSpaceOptions,
-
+    "ProblemVertex",
+    "ProblemEdge",
+    "StaticProblemGraph",
+    "ImmutableStaticProblemGraph",
+    "ForwardStaticProblemGraph",
+    "BidirectionalStaticProblemGraph",
+    "StateSpace",
+    "StateSpaceOptions",
     # GeneralizedStateSpace
-    ClassVertex,
-    ClassEdge,
-    StaticClassGraph,
-    ImmutableStaticClassGraph,
-    ForwardStaticClassGraph,
-    BidirectionalStaticClassGraph,
-
-    GeneralizedStateSpace,
-    GeneralizedStateSpaceOptions,
-
+    "ClassVertex",
+    "ClassEdge",
+    "StaticClassGraph",
+    "ImmutableStaticClassGraph",
+    "ForwardStaticClassGraph",
+    "BidirectionalStaticClassGraph",
+    "GeneralizedStateSpace",
+    "GeneralizedStateSpaceOptions",
     # StateSpaceSampler
-    StateSpaceSampler,
-
+    "StateSpaceSampler",
     # TupleGraph
-    TupleGraphVertex,
-    StaticTupleGraph,
-    ImmutableStaticTupleGraph,
-    ForwardStaticTupleGraph,
-    BidirectionalStaticTupleGraph,
-
-    TupleGraphOptions,
-    TupleGraph,
-
+    "TupleGraphVertex",
+    "StaticTupleGraph",
+    "ImmutableStaticTupleGraph",
+    "ForwardStaticTupleGraph",
+    "BidirectionalStaticTupleGraph",
+    "TupleGraphOptions",
+    "TupleGraph",
     # KnowledgeBase
-    KnowledgeBase,
-    KnowledgeBaseOptions,
-
+    "KnowledgeBase",
+    "KnowledgeBaseOptions",
     # ObjectGraph
-    create_object_graph
+    "create_object_graph",
 ]


### PR DESCRIPTION
Tiny bug in __all__ of advanced.datasets __init__. Causes this error:

```
from pymimir.advanced.datasets import BidirectionalStaticClassGraph    # works

from pymimir.advanced.datasets import TupleGraph                       # works

from pymimir.advanced.datasets import *                                # uh-oh

Traceback (most recent call last):
  File "/work/rleap1/michael.aichmueller/miniconda/envs/rgnet_latest/lib/python3.12/site-packages/IPython/core/interactiveshell.py", line 3699, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-6-73591edb8ce5>", line 1, in <module>
    from pymimir.advanced.datasets import *
  File "<frozen importlib._bootstrap>", line 1410, in _handle_fromlist
  File "<frozen importlib._bootstrap>", line 1406, in _handle_fromlist
TypeError: Item in pymimir.advanced.datasets.__all__ must be str, not nb_type_0
```

PR should fix this (I think)