### PR TITLE
suppress leak warnings globally

### DIFF
--- a/python/src/pymimir/CMakeLists.txt
+++ b/python/src/pymimir/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 
 nanobind_add_module(pymimir
+    NB_DOMAIN pymimir_abi_domain
     advanced/main.cpp
     advanced/common/bindings.cpp
     advanced/formalism/bindings.cpp

--- a/python/src/pymimir/advanced/main.cpp
+++ b/python/src/pymimir/advanced/main.cpp
@@ -25,6 +25,9 @@ namespace mimir
 
 NB_MODULE(pymimir, m)
 {
+#ifdef NDEBUG
+    nb::set_leak_warnings(false);
+#endif
     // Create submodules before binding to avoid missing bindings
     auto advanced = m.def_submodule("advanced");
     m.attr("advanced") = advanced;


### PR DESCRIPTION
This change would suppress the leak messages of issue #26. 
This is a patch to not confuse users of the library with these sorts of messages. It does not fix the underlying issue.

The suppression is guarded by NDEBUG, so that in debug compilations the problem could still be worked on, but e.g. wheels would be built with suppressed warnings.

I also followed nanobind's advise of ensuring pymimir is then built with its own ABI domain, since all nanobind extensions seem to share a runtime (and thus the suppression would affect other extensions then).