### PR TITLE
Update python versions, build wheel for python 3.14

### DIFF
--- a/.github/workflows/build_sdist.yml
+++ b/.github/workflows/build_sdist.yml
@@ -9,8 +9,6 @@ jobs:
   build_wheels:
     runs-on: ubuntu-latest
 
-    if: github.repository_owner == 'simon-stahlberg'
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -29,6 +27,7 @@ jobs:
         run: python setup.py sdist
 
       - name: Upload to PyPI
+        if: github.ref == 'refs/heads/main' && github.repository_owner == 'simon-stahlberg'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build_sdist.yml
+++ b/.github/workflows/build_sdist.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       with:
         ref: main
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
 

--- a/.github/workflows/build_sdist.yml
+++ b/.github/workflows/build_sdist.yml
@@ -12,26 +12,24 @@ jobs:
     if: github.repository_owner == 'simon-stahlberg'
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-      with:
-        ref: main
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: "3.10"
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
 
-    - name: Install dependencies and requirements
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install setuptools twine
+      - name: Install dependencies and requirements
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools twine
 
-    - name: Build source distribution
-      run: python setup.py sdist
+      - name: Build source distribution
+        run: python setup.py sdist
 
-    - name: Upload to PyPI
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload --skip-existing --repository-url https://upload.pypi.org/legacy/ dist/*
+      - name: Upload to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload --skip-existing --repository-url https://upload.pypi.org/legacy/ dist/*

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -2,8 +2,6 @@ name: Build Wheels for Linux
 
 on:
   push:
-    branches:
-      - main
 
 jobs:
   build_wheels:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
-      with:
-        ref: main
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -13,7 +13,7 @@ jobs:
         # "i686" (32-bit x86), "ppc64le" (PowerPC), "s390x" (IBM Z), "armv7l" (32-bit ARM)
         # The user can still build Mimir locally if they need it.
         architecture: ["x86_64"]  # TODO: Add "aarch64"
-        python-version: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313"]
+        python-version: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -17,8 +17,6 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
-    if: github.repository_owner == 'simon-stahlberg'
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
@@ -42,6 +40,7 @@ jobs:
         CIBW_BUILD_VERBOSITY: "1"
 
     - name: Upload to PyPI
+      if: github.ref == 'refs/heads/main' && github.repository_owner == 'simon-stahlberg'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         ref: main
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"  # Use a fixed version for the setup step
 

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -11,7 +11,7 @@ jobs:
         # "i686" (32-bit x86), "ppc64le" (PowerPC), "s390x" (IBM Z), "armv7l" (32-bit ARM)
         # The user can still build Mimir locally if they need it.
         architecture: ["x86_64"]  # TODO: Add "aarch64"
-        python-version: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
+        python-version: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
-      with:
-        ref: main
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         ref: main
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"  # Use a fixed version for the setup step
 

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -2,8 +2,6 @@ name: Build Wheels for macOS
 
 on:
   push:
-    branches:
-      - main
 
 jobs:
   build_wheels:

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -13,8 +13,6 @@ jobs:
         os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
-    if: github.repository_owner == 'simon-stahlberg'
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
@@ -38,6 +36,7 @@ jobs:
         CIBW_BUILD_VERBOSITY: "1"
 
     - name: Upload to PyPI
+      if: github.ref == 'refs/heads/main' && github.repository_owner == 'simon-stahlberg'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -9,7 +9,7 @@ jobs:
   build_wheels:
     strategy:
       matrix:
-        python-version: ["cp39", "cp310", "cp311", "cp312", "cp313"]
+        python-version: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
         os: [macos-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Deploy Doxygen Documentation
         uses: DenverCoder1/doxygen-github-pages-action@v2.0.0

--- a/.github/workflows/integrationtests-linux.yml
+++ b/.github/workflows/integrationtests-linux.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - name: Checkout Mimir
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.10"
 

--- a/.github/workflows/integrationtests-macos.yml
+++ b/.github/workflows/integrationtests-macos.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
     - name: Checkout Mimir
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     - name: Configure, Build, and Install Dependencies
       run: |

--- a/.github/workflows/pip-linux.yml
+++ b/.github/workflows/pip-linux.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          ref: main
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/pip-linux.yml
+++ b/.github/workflows/pip-linux.yml
@@ -10,11 +10,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: "3.8"
-          - os: ubuntu-latest
-            python-version: "3.9"
-          - os: ubuntu-latest
             python-version: "3.10"
+          - os: ubuntu-latest
+            python-version: "3.11"
+          - os: ubuntu-latest
+            python-version: "3.12"
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}

--- a/.github/workflows/pip-linux.yml
+++ b/.github/workflows/pip-linux.yml
@@ -10,11 +10,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: "3.10"
-          - os: ubuntu-latest
             python-version: "3.11"
           - os: ubuntu-latest
             python-version: "3.12"
+          - os: ubuntu-latest
+            python-version: "3.14t"
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}

--- a/.github/workflows/pip-linux.yml
+++ b/.github/workflows/pip-linux.yml
@@ -21,11 +21,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: main
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pip-macos.yml
+++ b/.github/workflows/pip-macos.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/pip-macos.yml
+++ b/.github/workflows/pip-macos.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.14t"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/pip-macos.yml
+++ b/.github/workflows/pip-macos.yml
@@ -15,11 +15,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: main
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pip-macos.yml
+++ b/.github/workflows/pip-macos.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          ref: main
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/unittests-linux.yml
+++ b/.github/workflows/unittests-linux.yml
@@ -12,7 +12,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.14t"
 
     - name: Install python requirements
       run: |

--- a/.github/workflows/unittests-linux.yml
+++ b/.github/workflows/unittests-linux.yml
@@ -8,9 +8,9 @@ jobs:
 
     steps:
     - name: Checkout Mimir
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.14t"
 

--- a/.github/workflows/unittests-macos.yml
+++ b/.github/workflows/unittests-macos.yml
@@ -12,7 +12,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: "3.14t"
 
     - name: Install python requirements
       run: |

--- a/.github/workflows/unittests-macos.yml
+++ b/.github/workflows/unittests-macos.yml
@@ -8,9 +8,9 @@ jobs:
 
     steps:
     - name: Checkout Mimir
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.14t"
 

--- a/dependencies/nanobind/CMakeLists.txt
+++ b/dependencies/nanobind/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(nanobind QUIET PATHS ${CMAKE_INSTALL_PREFIX} NO_DEFAULT_PATH)
 if (NOT nanobind_FOUND)
     list(APPEND CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
+            -DNB_TEST=OFF
     )
 
     message(STATUS "Preparing external project \"nanobind\" with args:")
@@ -27,12 +28,11 @@ if (NOT nanobind_FOUND)
     ExternalProject_Add(
             nanobind
             GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-            GIT_TAG v2.7.0
+            GIT_TAG v2.11.0
             PREFIX ${CMAKE_BINARY_DIR}/nanobind
             CMAKE_ARGS ${CMAKE_ARGS}
     )
 else()
     message(STATUS "nanobind is already installed.")
 endif()
-
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "nanobind",
     "wheel",
     "cmake>=3.21",
     "ninja",

--- a/python/src/pymimir/CMakeLists.txt
+++ b/python/src/pymimir/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 
 nanobind_add_module(pymimir
+    FREE_THREADED  # automatically ignored by nanobind if python version is not ft
     NB_DOMAIN pymimir_abi_domain
     advanced/main.cpp
     advanced/common/bindings.cpp

--- a/setup.py
+++ b/setup.py
@@ -52,11 +52,13 @@ class CMakeBuild(build_ext):
         )
 
         subprocess.run(
-            ["cmake", "--build", f"{str(temp_directory / 'dependencies' / 'build')}", f"-j{multiprocessing.cpu_count()}"]
+            ["cmake", "--build", f"{str(temp_directory / 'dependencies' / 'build')}", f"-j{multiprocessing.cpu_count()}"],
+            check=True
         )
 
         subprocess.run(
-            ["cmake", "--install", f"{str(temp_directory / 'dependencies' / 'build')}"]
+            ["cmake", "--install", f"{str(temp_directory / 'dependencies' / 'build')}"],
+            check=True
         )
 
         shutil.rmtree(f"{str(temp_directory / 'dependencies' / 'build')}")


### PR DESCRIPTION
Hi,

As the title suggests, PR would add py3.14 to the wheel building. 
Also,
- would move the tests to Python 3.10+, since both 3.8 and 3.9 have reached EOL.
- moved the tests to more recent python version and included free threading versions explicitly. 
- sunset python 3.8 (already was the case on macos)
- let wheels be built for all branches, upload only from main and owner == stahlberg (avoids merging PRs to main to find out wheels no longer build)
- updated CI action version